### PR TITLE
[RFR] Made it possible to use gulpfile.babel.js

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -134,7 +134,7 @@ echo "export PATH=\"\$HOME/vendor/node/bin:\$HOME/bin:\$HOME/node_modules/.bin:\
 
 # Check and run gulp
 (
-  if [ -f $build_dir/gulpfile.js ]; then
+  if [ -f $build_dir/gulpfile.js ] || [ -f $build_dir/gulpfile.babel.js ]; then
     # get the env vars
     if [ -d "$env_dir" ]; then
       status "Exporting config vars to environment"


### PR DESCRIPTION
When using Gulp through an ES6 Gulpfile, the filename is `gulpfile.babel.js` instead of `gulpfile.js`, resulting in the script failing to find the Gulpfile. This pull request intends to fix this.
